### PR TITLE
added dart 2 compat

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,9 @@ version: 0.1.3
 author: rio permana <rio.prmn@gmail.com>
 homepage: https://github.com/ripsware/community_material_icon
 
+environment:
+  sdk: '>=1.19.0 <3.0.0'
+
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
After updating to Flutter 0.6 I now get dependency warnings that prevent me from using this package stating "version resolving failed" due to me running dart 2.1.x. Easy fix by increasing the pubspec.yaml environment to allow anything less than dart 3.0.0.